### PR TITLE
fix urls: Escape values in URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func readCredentials() (string, string, error) {
 
 	fmt.Printf("Password: ")
 	password, err := terminal.ReadPassword(syscall.Stdin)
+	fmt.Println()
 
 	// If an error occured, I don't care about which one it is.
 	return strings.TrimSpace(username), strings.TrimSpace(string(password)), err

--- a/urls.go
+++ b/urls.go
@@ -1,19 +1,37 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
 
 const urlFormat string = "https://%s%s"
-const triggerChallengeUri = "/?action=sslvpn_logon&fw_username=%s&fw_password=%s&style=fw_logon_progress.xsl&fw_logon_type=logon&fw_domain=Firebox-DB"
-const responseUri = "/?action=sslvpn_logon&style=fw_logon_progress.xsl&fw_logon_type=response&response=%s&fw_logon_id=%d"
+const uriFormat = "/?%s"
 
 func templateChallengeTriggerUri(username *string, password *string) string {
-	return fmt.Sprintf(triggerChallengeUri, *username, *password)
+	v := url.Values{}
+	v.Set("action", "sslvpn_logon")
+	v.Set("style", "fw_logon_progress.xsl")
+	v.Set("fw_logon_type", "logon")
+	v.Set("fw_domain", "Firebox-DB")
+	v.Set("fw_username", *username)
+	v.Set("fw_password", *password)
+
+	return fmt.Sprintf(uriFormat, v.Encode())
 }
 
 func templateResponseUri(logonId int, token *string) string {
-	return fmt.Sprintf(responseUri, *token, logonId)
+	v := url.Values{}
+	v.Set("action", "sslvpn_logon")
+	v.Set("style", "fw_logon_progress.xsl")
+	v.Set("fw_logon_type", "response")
+	v.Set("response", *token)
+	v.Set("fw_logon_id", strconv.Itoa(logonId))
+
+	return fmt.Sprintf(uriFormat, v.Encode())
 }
 
 func templateUrl(baseUrl *string, uri string) string {
-	return fmt.Sprintf("https://%s%s", *baseUrl, uri)
+	return fmt.Sprintf(urlFormat, *baseUrl, uri)
 }


### PR DESCRIPTION
For usernames and passwords containing special characters the URL parameters
must be escaped.

Because the entire URI is just query parameters I've opted for using net/url.Values
for the entire URI.

Fixes #1